### PR TITLE
Allow to override `since`

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,8 +25,7 @@ if (config._[0] === 'load') {
   var load = require('../lib/load')(config.database, config.elasticsearch, config.mapper, config.addRaw, log)
   load.pipe(process.stdout)
 } else {
-
-  getLastChange(config, function (err, since) {
+  getSince(config, function (err, since) {
     if (err) {
       console.log('an error occured', err)
       console.log('since: now')
@@ -71,3 +70,12 @@ function getLastChange (config, cb) {
 
   })
 }
+
+function getSince(config, cb) {
+  if (config.since) {
+    cb(null, config.since)
+  } else {
+    getLastChange(config, cb)
+  }
+}
+

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -31,19 +31,21 @@ if (config._[0] === 'load') {
       console.log('since: now')
       since = null
     }
-    else console.log('since:', since)
+    else {
+      console.log('since:', since)
+    }
     console.log('end_on_catchup:', config.end_on_catchup)
     console.log('logging to:', getLogPath(config))
     require('../lib')(config.database, config.elasticsearch, config.mapper, config.addRaw, log, since, config.end_on_catchup)
   })
 }
 
-function getLogPath (config) {
+function getLogPath(config) {
   var filename = md5(config.elasticsearch) + '.log'
   return path.resolve(config.bunyan_base_path, filename)
 }
 
-function getLogFile (config) {
+function getLogFile(config) {
   mkdirp.sync(config.bunyan_base_path)
   var filename = md5(config.elasticsearch) + '.log'
   var where = path.resolve(config.bunyan_base_path, filename)
@@ -51,23 +53,26 @@ function getLogFile (config) {
   var log = bunyan.createLogger({
     name: 'couch2elastic4sync',
     streams: [{
-        path: where
+      path: where
     }]
   })
   return log
 }
 
-function getLastChange (config, cb) {
+function getLastChange(config, cb) {
   var logpath = getLogPath(config)
   lastLine(logpath, function (err, res) {
-    if (err) return cb(err)
+    if (err) {
+      return cb(err)
+    }
 
     try {
       var last_log = JSON.parse(res)
       cb(null, last_log.change)
 
-    } catch(e) { cb(e) }
-
+    } catch (e) {
+      cb(e)
+    }
   })
 }
 
@@ -78,4 +83,3 @@ function getSince(config, cb) {
     getLastChange(config, cb)
   }
 }
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,13 +12,13 @@ module.exports = function (couchdb, eleasticsearch, mapper, addRaw, log, since, 
 
 
   var shutdown = function () {
-    if (Object.keys(pending).length ) return
+    if (Object.keys(pending).length) return
     process.exit(0)
   }
 
-  var onDone = function  (log, _id, _rev, type, seq, err, resp) {
+  var onDone = function (log, _id, _rev, type, seq, err, resp) {
     if (err) return log.error('error occured', type, _id, _rev, err)
-    log.info({ change: seq }, 'success. ', type, _id, _rev, err)
+    log.info({change: seq}, 'success. ', type, _id, _rev, err)
     delete pending[seq]
   }
 
@@ -42,25 +42,25 @@ module.exports = function (couchdb, eleasticsearch, mapper, addRaw, log, since, 
         doc = mapped
       } catch (e) {
         delete pending[change.seq]
-        return log.error({ change: feed.original_db_seq }, change.doc._id, _rev, 'An error occured in the mapping', e)
+        return log.error({change: feed.original_db_seq}, change.doc._id, _rev, 'An error occured in the mapping', e)
       }
     }
     if (!doc) {
       delete pending[change.seq]
-      return log.error({ change: feed.original_db_seq }, change.doc._id, _rev, 'No document came back from the mapping')
+      return log.error({change: feed.original_db_seq}, change.doc._id, _rev, 'No document came back from the mapping')
     }
     jsonist.put(es_doc_url, doc, onDone.bind(null, log, change.doc._id, _rev, 'update', change.seq))
   })
 
   if (end_on_catchup) {
-    feed.on('catchup', function() {
+    feed.on('catchup', function () {
       feed.pause()
       setInterval(shutdown, 400)
     })
   }
 
-  feed.on('confirm', function(info) {
-    log.info({ change: feed.original_db_seq }, 'started')
+  feed.on('confirm', function (info) {
+    log.info({change: feed.original_db_seq}, 'started')
   })
 
 }

--- a/lib/load.js
+++ b/lib/load.js
@@ -22,7 +22,7 @@ module.exports = function (couchdb, eleasticsearch, mapper, addRaw, log) {
     }))
     //
     .pipe(to_couch(to_elastic_config)) // this is actually piping to elasticsearch
-    .on('error', function(err) {
+    .on('error', function (err) {
       log.error('document error', err)
     })
     .pipe(ndjson.stringify())


### PR DESCRIPTION
When starting from scratch, it helps to allow starting from `update_seq=0` instead of `now`. This change introduces a config property `since` to allow such a setting. I also took the freedom to apply some code format, but it's kept in a dedicated commit so that you can opt to drop the reformat.
