### PR TITLE
Filter documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,46 @@ is a simple node process that will follow a couchdb changes feed and updates ela
 
 You can also include an optional mapper.
 
-```
+```sh
 npm install couch2elastic4sync -g
 ```
 
 ## Usage
 
-[rc](http://npm.im/rc) is used to set to variables. For example, create a .couch2elastic4sync file with the following
+### Configuration file
 
-    database=http://localhost:5984/idx-edm-v5
-    elasticsearch=http://elastic-1.com:9200/idx-edm-v5/listing
+[rc](http://npm.im/rc) is used to set to variables. For example, create a .couch2elastic4sync file with the following
+```ini
+database=http://localhost:5984/idx-edm-v5
+elasticsearch=http://elastic-1.com:9200/idx-edm-v5/listing
+```
+
+or pass the config file path explicity
+```ini
+couch2elastic4sync --config=path/to/configfile
+```
+
+Alternatively, the config file can be in JSON
+```json
+{
+  "database": "http://localhost:5984/idx-edm-v5",
+  "elasticsearch": "http://elastic-1.com:9200/idx-edm-v5/listing"
+}
+```
+
+### Load documents
 
 To load all the documents into elasticsearch, run
+```sh
+couch2elastic4sync load
+```
 
-    couch2elastic4sync load
+### Keep documents in sync
 
 To keep a sync process going, run
-
-    couch2elastic4sync
-
+```sh
+couch2elastic4sync
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ To keep a sync process going, run
 couch2elastic4sync
 ```
 
+### Filter documents
+
+You can filter documents that should be loaded or kept in sync by setting a filter function in the config file.
+Example:
+```json
+{
+  "database": "http://localhost:5984/idx-edm-v5",
+  "elasticsearch": "http://elastic-1.com:9200/idx-edm-v5/listing",
+  "filter": "(doc) => doc.type === 'some-listing-type'"
+}
+```
+Just like you would expect a [CouchDB filter function](http://docs.couchdb.org/en/1.6.1/couchapp/ddocs.html#filter-functions) to behave:
+> [returning] true means that doc passes the filter rules, false means that it does not.
+
+**NB**: Make sure that your function can be parsed by [`eval`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#eval_as_a_string_defining_function_requires_(_and_)_as_prefix_and_suffix)
+
 ## License
 
 MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var once = require('lodash').once
 var remove_meta = require('ndjson-to-elasticsearch/lib/remove-meta')
 
 module.exports = function (config, log, since) {
+  var filter = eval(config.filter)
   var _retry = async.retry.bind(null, config.retry)
   var follow_config = {
     db: config.database,
@@ -57,6 +58,7 @@ module.exports = function (config, log, since) {
 
   var q = async.queue(function (change, endTask) {
     if (change.id.indexOf('_design') === 0) return endTask()
+    if (filter && !filter(change.doc)) return endTask()
 
     var doc = change.doc
     var es_doc_url = config.elasticsearch + '/' + change.id

--- a/lib/load.js
+++ b/lib/load.js
@@ -12,6 +12,8 @@ module.exports = function (config, log, done) {
   to_elastic_config.urlTemplate = config.urlTemplate
   to_elastic_config.removeMeta = config.removeMeta
   to_elastic_config.key = config.key || '_id'
+  // a filter function can be set in config as a string
+  var filter = eval(config.filter)
 
   return hyperquest(config.database + '/_all_docs?include_docs=true')
     .pipe(jsonfilter('rows.*'))
@@ -19,6 +21,8 @@ module.exports = function (config, log, done) {
     .pipe(through2.obj(function (row, enc, cb) {
       // ignore design docs
       if (row.id.indexOf('_design') === 0) return cb()
+      // if a filter function is defined, ignore documents that return false
+      if (filter && !filter(row.doc)) return cb()
       var result = row.doc
       if (config.mapper) {
         result = config.mapper(row.doc)


### PR DESCRIPTION
Allowing to pass a filter function through the configuration file to be applied on load and sync to determine which documents should be sent to ElasticSearch.

Designed to address cases of CouchDB databases with several document types, where only some should be passed to ElasticSearch.

Configuration example:
```json
{
  "database": "http://localhost:5984/idx-edm-v5",
  "elasticsearch": "http://elastic-1.com:9200/idx-edm-v5/listing",
  "filter": "(doc) => doc.type === 'some-listing-type'"
}
```

I'm using a ES6 arrow function here and in the README as it's more elegant: the same can be done with the classic function syntax, but you should not forget the ["(" and ")" as prefix and suffix](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#eval_as_a_string_defining_function_requires_(_and_)_as_prefix_and_suffix) to make it parsable by the `eval` function:
```
  "filter": "(function (doc) { return doc.type === 'some-listing-type' })"
```