### PR TITLE
Seq to Elastic Index instead of mapping metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ couch2elastic4sync id 19404098
 
 where it is the id from couch
 
+### Cleanup deleted docs
+
+Sometimes there are docs in elasticsearch, that dont match any docs in couch. This task cleans those up (removes them) from elasticsearch.
+
+
+```
+couch2elastic4sync cleanup
+```
+
+
 ### Format and filter documents
 
 A `mapper` function can be passed from the config to format documents before being put to ElasticSearch:
@@ -81,6 +91,27 @@ module.exports = function (doc) {
 ```
 
 If the function returns empty, the document is filtered-out
+
+### Template URLs and Templated Index Names
+A lodash template can be used based on document logic to define a elastic URL. This allows for different servers, index names and types to be defined based on the couch document or document returned from the mapper.
+```
+couch=http://localhost:5984
+database=idx-edm
+elasticsearch=http://<% if(doc_type === \'v5Doc\' ) { %>elastic-1.com:9200/idx-edm-v5/listing<% } else { %>elastic-1.com:9200/idx-edm-v6/listing<% } %>
+urlTemplate=true
+```
+
+### Sync last Seq
+The last seen Seq number is now saved in a elastic index called .couch2elastic4sync. If elastic is not configured (default) to create missing indexes, you will need
+to manually create this index. Alternatively you can change the config and provide a alternate index name under which the tracking information will be saved. A unique
+document is created for each url or urltemplate and couchdb configuration. 
+```
+couch=http://localhost:5984
+database=idx-edm
+elasticsearch=http://<% if(doc_type === \'v5Doc\' ) { %>elastic-1.com:9200/idx-edm-v5/listing<% } else { %>elastic-1.com:9200/idx-edm-v6/listing<% } %>
+urlTemplate=true
+seqIndex=.couchdbSyncConfig
+```
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ module.exports = function (config, log, since) {
   var shutdown = function () {
     log.info('shutdown called')
     if (!last_seen_seq) return process.exit(0)
-    jsonist.put(config.seq_url, {_meta: {seq: last_seen_seq }}, function (err, resp) {
+    jsonist.put(config.seq_url, { seq: last_seen_seq, date: new Date(), type: 'shutdown' }, function (err, resp) {
       if (err) log.error('Could not record sequence in elasticsearch', last_seen_seq, err)
       else log.info({type: 'checkpoint', seq: last_seen_seq}, 'stored in elasticsearch')
       process.exit(0)
@@ -41,12 +41,14 @@ module.exports = function (config, log, since) {
     if (_prev_es_doc) logged.doc = _prev_es_doc
     log.info(logged, 'success')
     checkpoint_counter++
-    if (!updating_checkpoint_counter && checkpoint_counter > config.checkpointSize) {
+    if (!updating_checkpoint_counter && (config.noCheckPoint || checkpoint_counter > config.checkpointSize)) {
       updating_checkpoint_counter = true
       checkpoint_counter = 0
       // store the thing change seq
-      jsonist.put(config.seq_url, {_meta: {seq: seq }}, function (err, resp) {
+      console.log('_____DOING THIS PUTTING AT ' + config.seq_url)
+      jsonist.put(config.seq_url, { seq: seq, date: new Date(), type: 'change' }, function (err, resp) {
         updating_checkpoint_counter = false
+        config.noCheckPoint = false
         if (err) log.error('Could not record sequence in elasticsearch', seq, err)
         else log.info({type: 'checkpoint', seq: last_seen_seq}, 'stored in elasticsearch')
         return endTask()
@@ -60,10 +62,7 @@ module.exports = function (config, log, since) {
 
     var doc = change.doc
     var es_doc_url = config.elasticsearch + '/' + change.id
-    if (config.key) es_doc_url = config.elasticsearch + '/' + doc[config.key]
-    if (config.urlTemplate) es_doc_url = run_compile(es_doc_url, doc, log)
-    if (doc._deleted) return handle_delete(config, es_doc_url, change, log, onDone, endTask)
-
+    
     var _rev = doc._rev
     if (config.mapper) {
       try {
@@ -76,6 +75,12 @@ module.exports = function (config, log, since) {
         return endTask()
       }
     }
+
+    // run key and _deleted after mapper as mapper may change those as with load
+    if (config.key) es_doc_url = config.elasticsearch + '/' + doc[config.key]
+    if (config.urlTemplate) es_doc_url = run_compile(es_doc_url, doc, log)
+    if (doc._deleted) return handle_delete(config, es_doc_url, change, log, onDone, endTask)
+
     if (!doc) {
       log.error({change: feed.original_db_seq}, change.doc._id, _rev, 'No document came back from the mapping')
       return endTask()

--- a/lib/load.js
+++ b/lib/load.js
@@ -39,7 +39,7 @@ module.exports = function (config, log, done) {
       // save the seq
       jsonist.get(config.database, function (err, about) {
         if (err) return done(err)
-        jsonist.put(config.seq_url, {_meta: {seq: about.update_seq }}, function (err, resp) {
+        jsonist.put(config.seq_url, {seq: about.update_seq, date: new Date(), type: 'load'}, function (err, resp) {
           return done(err)
         })
       })


### PR DESCRIPTION
This adds the last seen seq to a specific elastic index. It also fixes some issues related to the url template using the mapper document in Load but not in Sync and updates the ReadMe to include URL Template usage. Fixes ryanramage/couch2elastic4sync#18, fixes ryanramage/couch2elastic4sync/issues#17, fixes ryanramage/couch2elastic4sync/issues#16 and resolves ryanramage/couch2elastic4sync/issues#14