### PR TITLE
Escapes the URL before adding document

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var jsonist = require('jsonist')
 var template = require('lodash').template
 var once = require('lodash').once
 var remove_meta = require('ndjson-to-elasticsearch/lib/remove-meta')
+var querystring = require("querystring")
 
 module.exports = function (config, log, since) {
   var _retry = async.retry.bind(null, config.retry)
@@ -59,7 +60,7 @@ module.exports = function (config, log, since) {
     if (change.id.indexOf('_design') === 0) return endTask()
 
     var doc = change.doc
-    var es_doc_url = config.elasticsearch + '/' + change.id
+    var es_doc_url = config.elasticsearch + '/' + querystring.escape(change.id)
     if (config.key) es_doc_url = config.elasticsearch + '/' + doc[config.key]
     if (config.urlTemplate) es_doc_url = run_compile(es_doc_url, doc, log)
     if (doc._deleted) return handle_delete(config, es_doc_url, change, log, onDone, endTask)


### PR DESCRIPTION
Allow using Unicode character in the document ID (in CouchDB). Without this escape function, the following error occurs:
```
{"name":"couch2elastic4sync","hostname":"zbra","pid":21052,"level":30,"msg":"putting to http://localhost:9200/test/idx/\u0000idea\u0000588e5501d4c2af7879798180ada017460c757b91f44751bcc10d164201a16346\u0000","time":"2019-03-20T15:26:37.650Z","v":0}
_http_client.js:137
      throw new TypeError('Request path contains unescaped characters');
      ^

TypeError: Request path contains unescaped characters
    at new ClientRequest (_http_client.js:137:13)
    at Object.request (http.js:39:10)
    at Req._send (/home/ancha/.nvm/versions/node/v8.15.1/lib/node_modules/couch2elastic4sync/node_modules/jsonist/node_modules/hyperquest/index.js:136:21)
    at /home/ancha/.nvm/versions/node/v8.15.1/lib/node_modules/couch2elastic4sync/node_modules/jsonist/node_modules/hyperquest/index.js:50:21
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```
Signed-off-by: Antoine Chabert <antoine.chabert@tohero.fr>